### PR TITLE
Restore signal handling syscalls

### DIFF
--- a/linux-user/syscall.c
+++ b/linux-user/syscall.c
@@ -6333,7 +6333,11 @@ abi_long do_syscall(CPUArchState *cpu_env, int num, abi_long arg1,
             } else {
                 pact = NULL;
             }
-            ret = 0; // get_errno(do_sigaction(arg1, pact, &oact));
+#ifdef LLVM_HELPERS
+            ret = 0;
+#else
+            ret = get_errno(do_sigaction(arg1, pact, &oact));
+#endif
             if (!is_error(ret) && arg3) {
                 if (!lock_user_struct(VERIFY_WRITE, old_act, arg3, 0))
                     goto efault;
@@ -6388,7 +6392,11 @@ abi_long do_syscall(CPUArchState *cpu_env, int num, abi_long arg1,
                 }
             } else
                 oact = NULL;
-            ret = 0; // get_errno(do_sigaction(arg1, act, oact));
+#ifdef LLVM_HELPERS
+            ret = 0;
+#else
+            ret = get_errno(do_sigaction(arg1, act, oact));
+#endif
 	rt_sigaction_fail:
             if (act)
                 unlock_user_struct(act, arg2, 0);
@@ -6521,7 +6529,11 @@ abi_long do_syscall(CPUArchState *cpu_env, int num, abi_long arg1,
                 how = 0;
                 set_ptr = NULL;
             }
-            ret = 0; //get_errno(do_sigprocmask(how, set_ptr, &oldset));
+#ifdef LLVM_HELPERS
+            ret = 0;
+#else
+            ret = get_errno(do_sigprocmask(how, set_ptr, &oldset));
+#endif
             if (!is_error(ret) && arg3) {
                 if (!(p = lock_user(VERIFY_WRITE, arg3, sizeof(target_sigset_t), 0)))
                     goto efault;


### PR DESCRIPTION
An earlier commit in our qemu fork breaks signal handling, this is a partial revert of it that wraps changes related to syscalls in a `LLVM_HELPERS` macro.